### PR TITLE
Add a corrected version of go to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ So if you're running on Windows and YAP doesn't work make sure you don't have CR
 
 ### Requirements
 
-- [Go](http://www.golang.org)
+- [Go](http://www.golang.org) (for macOS make sure to use [version 1.8](https://golang.org/dl/go1.8.darwin-amd64.pkg)
 - [Git](https://git-scm.com/downloads)
 - bzip2
 - 6GB RAM


### PR DESCRIPTION
Tal says it doesn't work with versions higher than 1.8 in macOS. I don't know which versions work for linux. Need to check.